### PR TITLE
Fix failing parallelization test

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -31,7 +31,7 @@ def test_parallel_uses_multiple_processes():
 
 
 # The current method used to spawn processes doesn't give precise control over how many are spawned
-# so this test has been (for now)
+# so this test has been skipped (for now)
 @pytest.mark.skip
 def test_parallel_uses_correct_number_of_processes():
     """ Multiple processes are used up to the specified limit when possible. """


### PR DESCRIPTION
Should hopefully fix #21. For now I've skipped the failing test as it's not really necessary at the moment (it's probably safe to assume that the built-in Pool class works correctly) but it could be nice to have in the future if we implement our own pool of workers in the future.