### PR TITLE
Add BSD+Patent license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Memento contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -181,3 +181,7 @@ We'd like to acknowledge Joerg Wicker for supporting the project's ideation and 
 * [Joshua de Wet](https://github.com/Dewera)
 * [Nipun Jasti](https://github.com/watefeenex)
 * [James Lamberton](https://github.com/JamesLamberton)
+
+## License
+
+Memento is licensed under the [BSD+Patent](https://opensource.org/licenses/BSDplusPatent) license. This is a modified version of the [BSD](https://opensource.org/licenses/BSD-3-Clause) license which includes a patent grant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "memento"
 version = "0.1.0"
 description = "A Python library for running computationally expensive experiments"
 authors = ["Zac Pullar-Strecker <zacmps@gmail.com>", "Joshua de Wet", "Liam Scott-Russell <liam.scott.russell@gmail.com>", "Feras Albaroudi", "James Lamberton <j.w.lamberton@outlook.com>", "Nipun Jasti <nipunjasti@gmail.com>"]
-license = "MIT/Apache 2.0"
+license = "BSD-2-Clause-Patent"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Rationale: This license avoids having to MIT + Apache dual license to get GPLv2 compatibility and a patent grant.

Alternatives:
* MIT + Apache dual license - This is better known, but has the annoyance of being two licenses
* MIT - No patent grant
* Apache - Not GPLv2 compatible
* Unlicense - More uncertain enforcement in countries where committing work to the public domain is impossible (iirc Germany is a notable example)

@Liam-Scott-Russell @NeedsSoySauce @watefeenex @Dewera @JamesLamberton Please respond/react/approve affirmatively to confirm release of the code you have written under the license. This will be considered legally binding.
